### PR TITLE
Support of 63MB arguments passed on stack, various little changes and some bug fixes. Adding bandwidth scan for stackargs. Adding test for ve exception during async call.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ $(TARBALL): aveo.spec $(CWD)/prereqs/ve-urpc/.git
 	mkdir -p $(PACKAGE)-$(VERSION)
 	cp -p aveo.spec $(PACKAGE)-$(VERSION)
 	cp -rl Makefile make_aveo.inc prereqs README.md scripts src doc test VERSION COPYING $(PACKAGE)-$(VERSION)
+	rm -rf $(PACKAGE)-$(VERSION)/prereqs/ve-urpc/.git/*
 	tar czvf $(TARBALL) $(PACKAGE)-$(VERSION)
 	rm -rf $(PACKAGE)-$(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ clean:
 	make -C doc clean 
 	rm -f $(TARBALL)
 	rm -f aveo.spec
+	rm -f aveorun.spec
 realclean: clean
 	make -C prereqs/ve-urpc clean BUILD=$(BUILD) DEST=$(URPC_INST_DIR)
 	rm -rf $(BUILD) prereqs

--- a/aveo.spec.in
+++ b/aveo.spec.in
@@ -13,6 +13,8 @@ BuildRequires: vedebuginfo
 %if 0%{?rhel} == 8
 Requires: platform-python
 BuildRequires: platform-python-devel
+%define debug_package %{nil}
+%global __strip /bin/true
 %endif
 %description
 The Alternative VE Offloading framework (AVEO) is a faster and much

--- a/aveo.spec.in
+++ b/aveo.spec.in
@@ -27,6 +27,7 @@ OpenACC.
 %package devel
 Summary: Development package for VE Offloading Framework based on VE-UDMA RPC
 Requires: %{name} = %{version}-%{release}
+Obsoletes: veoffload-devel veoffload-veorun-devel
 %description devel
 This package includes header files of VE offloading Framework
 

--- a/aveorun.spec.in
+++ b/aveorun.spec.in
@@ -28,6 +28,7 @@ Summary: Development package for VE Offloading Framework based on VE-UDMA RPC
 Requires: glibc-ve-devel
 Requires: %{name} = %{version}-%{release}
 BuildRequires: glibc-ve-devel
+Obsoletes: veoffload-devel veoffload-veorun-devel
 %description devel
 This package includes header files of VE offloading Framework
 

--- a/doc/GettingStarted.md.in
+++ b/doc/GettingStarted.md.in
@@ -41,16 +41,7 @@ your program linked with the previous VEO implementation.
 
 To develop programs, @PACKAGE@-devel and @PACKAGE@run-devel and
 the development packages of the compiler (2.2.2 or later) are also
-required. These packages conflict with veoffload-devel and
-veoffload-veorun-devel. So, please uninstall veoffload-devel and
-veoffload-veorun-devel.
-
-To uninstall the conflicting packages by yum, execute the following
-command as root:
-
-~~~
-# yum remove veoffload-devel veoffload-veorun-devel
-~~~
+required.
 
 To install the packages to develop programs by yum, execute the
 following command as root:
@@ -58,6 +49,10 @@ following command as root:
 ~~~
 # yum install @PACKAGE@-devel @PACKAGE@run-devel
 ~~~
+veoffload-devel and veoffload-veorun-devel will be uninstalled
+automatically, because they conflict with @PACKAGE@-devel and
+@PACKAGE@run-devel.
+
 Then, you can link your program with AVEO.
 If you want to link your program with the previous VEO implementation,
 please install its packages into another machine.

--- a/doc/Restriction.md
+++ b/doc/Restriction.md
@@ -6,6 +6,8 @@ VEO does not support a quadruple precision real number and a variable length cha
 
 VEO does not support a quadruple precision real number and a variable length character string as a return value of Fortran functions.
 
+When veo_proc_create() is invoked, multiple threads for a OpenMP program are created on VE side by default. If you do not use OpenMP, set environment variable OMP_NUM_THREADS=1.
+
 Synchronous APIs wait the completion of previous requests submitted by asynchronous APIs.
 Synchronous APIs are below:
  - veo_alloc_mem()

--- a/doc/Restriction.md
+++ b/doc/Restriction.md
@@ -21,3 +21,5 @@ Synchronous APIs are below:
  - veo_read_mem()
  - veo_unload_library()
  - veo_write_mem()
+
+The size of arguments passed to functions is limited to 63MB, since the size of the initial stack is 64MB. Allocate and use memory buffers on heap when you have huge argument arrays to pass.

--- a/src/AsyncTransfer.cpp
+++ b/src/AsyncTransfer.cpp
@@ -21,7 +21,7 @@ namespace veo {
  */
 uint64_t Context::sendbuffAsync(uint64_t dst, void *src, size_t size)
 {
-  VEO_TRACE("sendbuffAsync enter...\n");
+  VEO_TRACE("sendbuffAsync enter...");
   if (this->state == VEO_STATE_EXIT)
     return VEO_REQUEST_ID_INVALID;
 
@@ -65,7 +65,7 @@ uint64_t Context::sendbuffAsync(uint64_t dst, void *src, size_t size)
   if(this->comq.pushRequest(std::move(cmd)))
     return VEO_REQUEST_ID_INVALID;
   this->progress(3);
-  VEO_TRACE("sendbuffAsync leave...\n");
+  VEO_TRACE("sendbuffAsync leave...");
   return id;
 }
 
@@ -79,7 +79,7 @@ uint64_t Context::sendbuffAsync(uint64_t dst, void *src, size_t size)
  */
 uint64_t Context::recvbuffAsync(void *dst, uint64_t src, size_t size)
 {
-  VEO_TRACE("recvbuffAsync enter...\n");
+  VEO_TRACE("recvbuffAsync enter...");
   if (this->state == VEO_STATE_EXIT)
     return VEO_REQUEST_ID_INVALID;
 
@@ -138,7 +138,7 @@ uint64_t Context::recvbuffAsync(void *dst, uint64_t src, size_t size)
   if(this->comq.pushRequest(std::move(cmd)))
     return VEO_REQUEST_ID_INVALID;
   this->progress(3);
-  VEO_TRACE("recvbuffAsync leave...\n");
+  VEO_TRACE("recvbuffAsync leave...");
   return id;
 }
 
@@ -152,7 +152,7 @@ uint64_t Context::recvbuffAsync(void *dst, uint64_t src, size_t size)
  */
 uint64_t Context::asyncReadMem(void *dst, uint64_t src, size_t size)
 {
-  VEO_TRACE("asyncReadMem enter...\n");
+  VEO_TRACE("asyncReadMem enter...");
   if( this->state == VEO_STATE_EXIT )
     return VEO_REQUEST_ID_INVALID;
 
@@ -210,7 +210,7 @@ uint64_t Context::asyncReadMem(void *dst, uint64_t src, size_t size)
       return VEO_REQUEST_ID_INVALID;
   }
   this->progress(3);
-  VEO_TRACE("asyncReadMem leave...\n");
+  VEO_TRACE("asyncReadMem leave...");
   return id;
 }
 
@@ -276,7 +276,7 @@ uint64_t Context::asyncWriteMem(uint64_t dst, const void *src,
              return rv;
            };
   std::unique_ptr<Command> req(new internal::CommandImpl(id, f));
-  dprintf("cmd is VH? %d", req.get()->isVH());
+  dprintf("cmd is VH? %d\n", req.get()->isVH());
   {
     std::lock_guard<std::mutex> lock(this->submit_mtx);
     if(this->comq.pushRequest(std::move(req)))

--- a/src/CallArgs.cpp
+++ b/src/CallArgs.cpp
@@ -277,7 +277,7 @@ std::vector<uint64_t> CallArgs::getRegVal(uint64_t sp) const {
  * @param[in,out] sp reference to stack pointer
  * @return stack image
  */
-std::string CallArgs::getStackImage(uint64_t &sp) {
+std::string CallArgs::getStackImage(uint64_t sp) {
   VEO_TRACE("getStackImage(%#lx)", sp);
   // allocate stack
   size_t stack_size = PARAM_AREA_OFFSET + 8 * this->numArgs()
@@ -307,7 +307,7 @@ std::string CallArgs::getStackImage(uint64_t &sp) {
   return stack;
 }
 
-void CallArgs::setup(uint64_t &sp)
+void CallArgs::setup(uint64_t sp)
 {
   VEO_TRACE("setup CallArgs (sp = %#lx)...", sp);
   auto img = this->getStackImage(sp);

--- a/src/CallArgs.hpp
+++ b/src/CallArgs.hpp
@@ -37,7 +37,7 @@ class CallArgs {
   template<typename T> void push_(T val);
   template<typename T> void set_(int argnum, T val);
 
-  std::string getStackImage(uint64_t &);
+  std::string getStackImage(uint64_t);
 
 public:
   uint64_t stack_top;
@@ -85,7 +85,7 @@ public:
 
   std::vector<uint64_t> getRegVal(uint64_t) const;
 
-  void setup(uint64_t &);
+  void setup(uint64_t);
   void copyin(std::function<int(uint64_t, const void *, size_t)>);
   void copyout();
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -342,7 +342,7 @@ uint64_t Context::doCallAsync(uint64_t addr, CallArgs &args)
              uint64_t extra_size = (uint64_t)args.stack_size
                - MAX_ARGS_STACK_SIZE + reg_args_sz;
              int rv;
-             if (args.copied_out) {
+             if (args.copied_in) {
                rv = this->writeMem(extra_stk, extra_buf, extra_size);
                if (rv != 0) {
                  VEO_ERROR("Writing memory failed! Aborting.");
@@ -362,7 +362,7 @@ uint64_t Context::doCallAsync(uint64_t addr, CallArgs &args)
                return status;
              }
 
-             if (args.copied_in) {
+             if (args.copied_out) {
                rv = this->readMem(extra_buf, extra_stk, extra_size);
                if (rv != 0) {
                  VEO_ERROR("Reading memory failed! Aborting.");

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -55,6 +55,9 @@ private:
     return ret;
   }
 
+  uint64_t simpleCallAsync(uint64_t, CallArgs &);
+  uint64_t doCallAsync(uint64_t, CallArgs &);
+
   // handlers for commands
   int _readMem(void *, uint64_t, size_t);
   int _writeMem(uint64_t, const void *, size_t);
@@ -79,6 +82,8 @@ public:
   uint64_t recvbuffAsync(void *dst, uint64_t src, size_t size);
   uint64_t asyncReadMem(void *dst, uint64_t src , size_t size);
   uint64_t asyncWriteMem(uint64_t dst, const void *src, size_t size);
+  int readMem(void *dst, uint64_t src , size_t size);
+  int writeMem(uint64_t dst, const void *src, size_t size);
 
   veo_thr_ctxt *toCHandle() {
     return reinterpret_cast<veo_thr_ctxt *>(this);

--- a/src/Makefile
+++ b/src/Makefile
@@ -113,7 +113,7 @@ $(BLIBEX)/aveorun-ftrace: $(BVE)/aveorun-ftrace.o | $$(@D)/
 		-lveio -lpthread
 
 $(BLIBEX)/relink_aveorun: ../scripts/relink_aveorun.in
-	sed -e "s,@libexecdir@,$(DEST)/libexec,g" -e "s,@velibdir@,$(BUILD)/lib,g" \
+	sed -e "s,@libexecdir@,$(DEST)/libexec,g" -e "s,@velibdir@,$(VEDEST)/lib,g" \
 		< $< > $@
 	chmod 755 $@
 

--- a/src/aveorun.c
+++ b/src/aveorun.c
@@ -22,27 +22,30 @@ void signalHandler( int signum ) {
   VEO_ERROR("Interrupt signal %d received", signum);
 
   // try to print info about stack trace
-  __builtin_traceback((unsigned long *)__builtin_frame_address(0));
-  void *f = __builtin_return_address(0);
-  if (f) {
-    if (dladdr(f, &di)) {
-      printf("%p -> %s\n", f, di.dli_sname);
-    } else {
-      printf("%p\n", f);
-    }
-    void *f = __builtin_return_address(1);
+  unsigned long frame = __builtin_frame_address(0);
+  if (frame) {
+    __builtin_traceback((unsigned long *)frame);
+    void *f = __builtin_return_address(0);
     if (f) {
       if (dladdr(f, &di)) {
         printf("%p -> %s\n", f, di.dli_sname);
       } else {
         printf("%p\n", f);
       }
-      void *f = __builtin_return_address(2);
+      void *f = __builtin_return_address(1);
       if (f) {
         if (dladdr(f, &di)) {
           printf("%p -> %s\n", f, di.dli_sname);
         } else {
           printf("%p\n", f);
+        }
+        void *f = __builtin_return_address(2);
+        if (f) {
+          if (dladdr(f, &di)) {
+            printf("%p -> %s\n", f, di.dli_sname);
+          } else {
+            printf("%p\n", f);
+          }
         }
       }
     }

--- a/src/veo_urpc.h
+++ b/src/veo_urpc.h
@@ -11,6 +11,15 @@
 // multipart SEND/RECVFRAG transfer size
 #define PART_SENDFRAG (6*1024*1024)
 
+// The maximum size of arguments we can send using URPC_CMD_CALL_STKxx.
+// 40 is the size to send message with "LPLLP".
+#define MAX_ARGS_STACK_SIZE (DATA_BUFF_END - 40)
+
+// The size of a reserved stack area to avoid overwrite of arguments
+// We chose a big value as possible as we can, because the code to
+// print debug messages use stack.
+#define RESERVED_STACK_SIZE 512*1024
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/veo_urpc_ve.c
+++ b/src/veo_urpc_ve.c
@@ -196,6 +196,10 @@ static int call_handler(urpc_peer_t *up, urpc_mb_t *m, int64_t req,
   }
   asm volatile("or %0, 0, %s0":"=r"(result));
 
+  // "cmd" seems to be overwritten when we call the function.
+  // We set "cmd", again
+  cmd = m->c.cmd;
+
   if (cmd == URPC_CMD_CALL_STKOUT ||
       cmd == URPC_CMD_CALL_STKINOUT) {
     // copying back from stack must happen in the same function,

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ TESTS = $(addprefix $(BB)/,test_callsync test_callasync test_stackargs \
  test_child1 test_child2 test_async_mem test_thread_main_call_race \
  test_2ctx_callasync test_omp test_omp_static test_arith_ftrace \
  test_stackout test_unloadlib test_noproc test_memtransfers \
- test_omp_2ctx)
+ test_veexcept_async bandwidth_stackargs test_omp_2ctx)
 
 VELIBS = $(addprefix $(BB)/,libvehello.so libvehello2.so \
  libvestackargs.so libveexcept.so libveasyncmem.so libvetestomp.so \
@@ -28,7 +28,7 @@ VELIBS = $(addprefix $(BB)/,libvehello.so libvehello2.so \
 STATICS = $(addprefix $(BB)/, veorun_testomp)
 
 SCRIPTS = $(addprefix $(BB)/,scan_bandwidth.sh scan_call_latency.sh \
- run_tests.sh)
+ run_tests.sh scan_bandwidth_stackargs.sh)
 
 
 ALL: $(TESTS) $(VELIBS) $(STATICS) $(SCRIPTS)

--- a/test/bandwidth_stackargs.c
+++ b/test/bandwidth_stackargs.c
@@ -1,0 +1,143 @@
+/*
+  gcc -o hello hello.c -I/opt/nec/ve/veos/include -L/opt/nec/ve/veos/lib64 \
+   -Wl,-rpath=/opt/nec/ve/veos/lib64 -lveo
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <ve_offload.h>
+#include <urpc_time.h>
+
+/* variables for VEO demo */
+int ve_node_number = 0;
+struct veo_proc_handle *proc = NULL;
+struct veo_thr_ctxt *ctx = NULL;
+
+int veo_init()
+{
+	int rc;
+	proc = veo_proc_create(-1);
+	if (proc == NULL) {
+		perror("ERROR: veo_proc_create");
+		return -1;
+	}
+
+#ifdef VEO_DEBUG
+	printf("If you want to attach to the VE process, you now have 20s!\n\n"
+	       "/opt/nec/ve/bin/gdb -p %d veorun_static\n\n", getpid());
+	sleep(20);
+#endif
+	ctx = veo_context_open(proc);
+	if (ctx == NULL) {
+		perror("ERROR: veo_context_open");
+		return -1;
+	}
+	return 0;
+}
+
+int veo_finish()
+{
+	veo_context_close(ctx);
+	veo_proc_destroy(proc);
+	return 0;
+}
+
+
+int main(int argc, char **argv)
+{
+	int i, rc, n, peer_id;
+	uint64_t ve_buff;
+	void *local_buff;
+	size_t bsize = 1024*1024, res;
+	long ts, te;
+	double bw;
+	int do_send = 1, do_recv = 1;
+        int ntransfer = 0;
+	
+	if (argc == 2) {
+		if (strcmp(argv[1], "-h") == 0) {
+			printf("Usage:\n");
+			printf("%s [<size>]\n");
+			printf("%s send|recv <size> [<loops>]]\n");
+			return 0;
+		} else {
+			bsize = atol(argv[1]);
+		}
+	} else if (argc >= 3) {
+		if (strcmp(argv[1], "send") == 0)
+			do_recv = 0;
+		else if (strcmp(argv[1], "recv") == 0)
+			do_send = 0;
+                else {
+			bsize = atol(argv[1]);
+			ntransfer = atoi(argv[2]);
+		}
+		if (do_send == 0 || do_recv == 0) {
+			bsize = atol(argv[2]);
+			if (argc > 3)
+				ntransfer = atoi(argv[3]);
+		}
+	}
+
+	rc = veo_init();
+	if (rc != 0)
+		exit(1);
+
+	local_buff = malloc(bsize);
+	// touch local buffer
+	//memset(local_buff, 65, bsize);
+	for (i = 0; i < bsize/sizeof(long); i++)
+		((long *)local_buff)[i] = (long)i;
+		
+
+	uint64_t handle = veo_load_library(proc, "./libvestackargs.so");
+	uint64_t sym = veo_get_sym(proc, handle, "test_bandwidth");
+	struct veo_args *arg = veo_args_alloc();
+
+	if (ntransfer > 0)
+		n = ntransfer;
+	else {
+		if (bsize < 512 * 1024)
+			n = (int)(100 * 1.e6 / (double)bsize);
+		else
+			n = (int)(5.0 * 1.e9 / (double)bsize);
+		n > 0 ? n : 1;
+	}
+
+	uint64_t req, retval;
+	if (do_send) {
+		veo_args_set_stack(arg, VEO_INTENT_IN, 0, (char *)local_buff, bsize);
+		ts = get_time_us();
+		for (i = 0; i < n; i++) {
+			req = veo_call_async(ctx, sym, arg);
+			res = veo_call_wait_result(ctx, req, &retval);
+		}
+		te = get_time_us();
+		bw = (double)bsize * n/((double)(te - ts)/1e6);
+		bw = bw / 1e6;
+		printf("veo_write_mem returned: %lu bw=%f MB/s\n", res, bw);
+	}
+
+	//overwrite local buffer
+	memset(local_buff, 65, bsize);
+
+	if (do_recv) {
+		veo_args_set_stack(arg, VEO_INTENT_OUT, 0, (char *)local_buff, bsize);
+		ts = get_time_us();
+		for (i = 0; i < n; i++) {
+			req = veo_call_async(ctx, sym, arg);
+			res = veo_call_wait_result(ctx, req, &retval);
+		}
+		te = get_time_us();
+		bw = (double)bsize * n/((double)(te - ts)/1e6);
+		bw = bw / 1e6;
+		printf("veo_read_mem returned: %lu bw=%f MB/s\n", res, bw);
+	}
+
+	veo_args_free(arg);
+	veo_finish();
+	exit(rc);
+}

--- a/test/libvestackargs.c
+++ b/test/libvestackargs.c
@@ -64,3 +64,8 @@ int test_16(int i16, unsigned int u16)
     printf("VE: argument passed: %hd, %hu\n", i16, u16);
     return 0;
 }
+
+int test_bandwidth(void *data)
+{
+    return 0;
+}

--- a/test/libvestackargs.c
+++ b/test/libvestackargs.c
@@ -14,6 +14,7 @@ void ftest(double *d, char *t, int *i)
 long test_many_args(double d0, double d1, double d2, double d3, double d4,
                     double d5, double d6, double d7, double d8, double d9)
 {
+	int a;
 	double result;
 	result = d0 + d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9;
 	printf("VE: %f + %f + %f + %f + %f + %f + %f + %f + %f + %f = %f\n",
@@ -22,6 +23,7 @@ long test_many_args(double d0, double d1, double d2, double d3, double d4,
 		double d;
 		long l;
 	} u;
+	printf("VE: sp = %p\n", (void *)&a);
 	u.d = result;
 	return u.l;
 }

--- a/test/scan_bandwidth_stackargs.sh
+++ b/test/scan_bandwidth_stackargs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+kbscan="1 4 16 32 64 96 128 256 512 768"
+mbscan="1 2 4 8 16 32 61"
+
+
+printf "%8s   %7s   %7s\n" "buff kB" "send MB/s" "recv MB/s"
+for s in $kbscan; do
+    bw=`./bandwidth_stackargs $((s * 1024)) | grep "bw=" | sed -e 's,^.*bw=,,' -e 's,\..*$,,'`
+    printf "%8d   %7.0f   %7.0f\n" $s $bw
+done
+for s in $mbscan; do
+    bw=`./bandwidth_stackargs $((s * 1024 * 1024)) | grep "bw=" | sed -e 's,^.*bw=,,' -e 's,\..*$,,'`
+    printf "%8d   %7.0f   %7.0f\n" $((s*1024)) $bw
+done

--- a/test/test_nprocs.c
+++ b/test/test_nprocs.c
@@ -1,3 +1,5 @@
+#define _DEFAULT_SOURCE /* for setenv */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -10,17 +12,22 @@ int main(int argc, char *argv[])
 {
   int err = 0, rc = 0;
   const int nprocs = 4;
+  int created_procs = 0;
 
   struct veo_proc_handle *proc[nprocs];
   uint64_t libh[nprocs], sym[nprocs];
 
+  setenv("OMP_NUM_THREADS", "4", 1);
+
+  for (int i = 0; i < nprocs; i++) {
+    proc[i] = NULL;
+  }
   for (int i = 0; i < nprocs; i++) {
     proc[i] = veo_proc_create(i % 2);
     printf("proc%d = %p\n", i, (void *)proc[i]);
-    if (proc[i] == NULL) {
-      rc = -1;
-      goto done;
-    }
+    if (proc[i] == NULL)
+      continue;
+    created_procs++;
 
     libh[i] = veo_load_library(proc[i], "./libvehello.so");
     printf("libh%d = %p\n", i, (void *)libh[i]);
@@ -39,6 +46,8 @@ int main(int argc, char *argv[])
 
   struct veo_args *argp = veo_args_alloc();
   for (int i = 0; i < nprocs; i++) {
+    if (proc[i] == NULL)
+      continue;
     uint64_t result = 0;
     veo_args_clear(argp);
     veo_args_set_i32(argp, 0, 42);
@@ -49,6 +58,10 @@ int main(int argc, char *argv[])
   veo_args_free(argp);
 
  done:
+  if (created_procs <= 1) {
+    printf("created_procs is %d\n", created_procs);
+    rc = -1;
+  }
   for (int i = 0; i < nprocs; i++) {
     if (proc[i] != NULL) {
       err = veo_proc_destroy(proc[i]);

--- a/test/test_veexcept_async.c
+++ b/test/test_veexcept_async.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <ve_offload.h>
+#include <urpc_time.h>
+
+int main(int argc, char *argv[])
+{
+  int err = 0, rc = 0;
+
+  struct veo_proc_handle *proc;
+  uint64_t libh, sym;
+  uint64_t req;
+
+  proc = veo_proc_create(-1);
+  printf("proc = %p\n", (void *)proc);
+  if (proc == NULL) {
+    rc = -1;
+    goto done;
+  }
+
+  libh = veo_load_library(proc, "./libveexcept.so");
+  printf("libh = %p\n", (void *)libh);
+  if (libh == 0) {
+    rc = -1;
+    goto done;
+  }
+  sym = veo_get_sym(proc, libh, "hello");
+  printf("'hello' sym = %p\n", (void *)sym);
+  if (libh == 0) {
+    rc = -1;
+    goto done;
+  }
+
+  struct veo_thr_ctxt *ctx = veo_context_open(proc);
+  printf("ctx = %p\n", (void *)ctx);
+  if (ctx == NULL) {
+    rc = -1;
+    goto done;
+  }
+
+  struct veo_args *argp = veo_args_alloc();
+  uint64_t result = 0;
+  veo_args_clear(argp);
+  veo_args_set_i32(argp, 0, 42);
+
+  req = veo_call_async(ctx, sym, argp);
+  if (req == VEO_REQUEST_ID_INVALID) {
+    printf("veo_call_async() failed\n");
+    rc = -1;
+    goto done;
+  }
+
+  rc = veo_call_wait_result(ctx, req, &result);
+  printf("call 'hello' on proc returned %ld, rc=%d\n", result, rc);
+  veo_args_free(argp);
+
+ done:
+  if (proc != NULL) {
+    err = veo_proc_destroy(proc);
+    printf("veo_proc_destroy(proc) returned %d\n", err);
+  }
+  if (rc == VEO_COMMAND_EXCEPTION)
+    return 0;
+  return -1;
+}
+


### PR DESCRIPTION
We'd like to support 63MB argument because the existing implementation of VEO supports 63MB argument. On the other hand, we'd like to keep AVEO use 32MB huge pages per a context because users will allocate 32MB huge pages per a VE core as per the instruction guide. So, we created a patch to transfer arguments using SENDBUF and RECVBUF command if the size is more than 31MB.

In addition to this, we created patches of bug fixes and miner enhancements.

Please pull them.

