### PR TITLE
Fixed a hang issue on waiting for request results after an exception occurs.

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -152,8 +152,15 @@ void CommQueue::cancelAll()
   for(;;) {
     auto command = this->request.popNoWait();
     if ( command == nullptr )
-      return;
-    command->setResult(0, VEO_COMMAND_UNFINISHED);
+      break;
+    command->setResult(0, VEO_COMMAND_ERROR);
+    this->completion.insert(std::move(command));
+  }
+  for(;;) {
+    auto command = this->inflight.popNoWait();
+    if ( command == nullptr )
+      break;
+    command->setResult(0, VEO_COMMAND_ERROR);
     this->completion.insert(std::move(command));
   }
 }


### PR DESCRIPTION
We need to set VEO_COMMAND_ERROR to requests in in-flight queue to avoid hang.