### PR TITLE
Fix makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ aveo.spec: aveo.spec.in
 aveorun.spec: aveorun.spec.in
 	$(edit) $< > $@
 
-
 $(TARBALL): aveo.spec $(CWD)/prereqs/ve-urpc/.git
 	if [ -d $(PACKAGE)-$(VERSION) ]; then rm -rf $(PACKAGE)-$(VERSION); fi
 	mkdir -p $(PACKAGE)-$(VERSION)
@@ -82,9 +81,12 @@ $(TARBALL): aveo.spec $(CWD)/prereqs/ve-urpc/.git
 	rm -rf $(PACKAGE)-$(VERSION)
 
 rpm: $(TARBALL) aveo.spec aveorun.spec
+	mkdir -p ${RPMBUILD_DIR}/SOURCES
 	cp $(TARBALL) ${RPMBUILD_DIR}/SOURCES
 	rpmbuild -D "%_topdir $(RPMBUILD_DIR)" -ba aveo.spec
 	rpmbuild -D "%_topdir $(RPMBUILD_DIR)" -ba aveorun.spec
+
+.PHONY: aveo.spec aveorun.spec $(TARBALL) rpm
 
 # --------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,11 @@ clean:
 	make -C src clean $(MAKEVARS)
 	make -C test clean $(MAKEVARS)
 	make -C doc clean 
+	make -C prereqs/ve-urpc clean BUILD=$(BUILD) DEST=$(URPC_INST_DIR)
 	rm -f $(TARBALL)
 	rm -f aveo.spec
 	rm -f aveorun.spec
 realclean: clean
-	make -C prereqs/ve-urpc clean BUILD=$(BUILD) DEST=$(URPC_INST_DIR)
 	rm -rf $(BUILD) prereqs
 
 .PHONY: aveo tests test install ve-urpc clean realclean doc

--- a/src/Makefile
+++ b/src/Makefile
@@ -102,14 +102,14 @@ $(BVELIB)/libaveoVE.a: $(VELIB_OBJS) $(BVE)/aveorun.o | $$(@D)/
 $(BLIB)/libveo.a: $(VHLIB_OBJS) | $$(@D)/
 	$(AR) rv $@ $^
 
-$(BLIBEX)/aveorun: $(BVE)/aveorun.o $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a | $$(@D)/
+$(BLIBEX)/aveorun: $(BVE)/aveorun.o $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE_omp.a | $$(@D)/
 	$(NFORT) $(NFORTFLAGS) -v -cxxlib -fopenmp -o $@ $^ \
-		$(NLDFLAGS) $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a \
+		$(NLDFLAGS) $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE_omp.a \
 		-lveio -lpthread
 
-$(BLIBEX)/aveorun-ftrace: $(BVE)/aveorun-ftrace.o $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a | $$(@D)/
+$(BLIBEX)/aveorun-ftrace: $(BVE)/aveorun-ftrace.o $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE_omp.a | $$(@D)/
 	$(NFORT) $(NFORTFLAGS) -ftrace -cxxlib -fopenmp -o $@ $^ \
-		$(NLDFLAGS) $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a \
+		$(NLDFLAGS) $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE_omp.a \
 		-lveio -lpthread
 
 $(BLIBEX)/relink_aveorun: ../scripts/relink_aveorun.in

--- a/src/Makefile
+++ b/src/Makefile
@@ -150,4 +150,6 @@ $(BVE)/aveorun-ftrace.o: aveorun.c | $$(@D)/
 	$(NCC) $(NCCFLAGS) -ftrace -fpic -o $@ -c $<
 
 clean:
-	rm -f $(VHLIB_OBJS) $(VELIB_OBJS) $(VELIB_OBJS_OMP) $(LIBS) $(LIBS) $(VELIBS) $(VEARCS) $(PROGS)
+	rm -f $(VHLIB_OBJS) $(VELIB_OBJS) $(VELIB_OBJS_OMP) $(LIBS) $(LIBS) \
+		$(VELIBS) $(VEARCS) $(PROGS) $(INCLUDES) \
+		$(BVE)/aveorun.o $(BVE)/aveorun-ftrace.o 

--- a/src/Makefile
+++ b/src/Makefile
@@ -102,12 +102,12 @@ $(BVELIB)/libaveoVE.a: $(VELIB_OBJS) $(BVE)/aveorun.o | $$(@D)/
 $(BLIB)/libveo.a: $(VHLIB_OBJS) | $$(@D)/
 	$(AR) rv $@ $^
 
-$(BLIBEX)/aveorun: $(BVE)/aveorun.o | $$(@D)/
+$(BLIBEX)/aveorun: $(BVE)/aveorun.o $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a | $$(@D)/
 	$(NFORT) $(NFORTFLAGS) -v -cxxlib -fopenmp -o $@ $^ \
 		$(NLDFLAGS) $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a \
 		-lveio -lpthread
 
-$(BLIBEX)/aveorun-ftrace: $(BVE)/aveorun-ftrace.o | $$(@D)/
+$(BLIBEX)/aveorun-ftrace: $(BVE)/aveorun-ftrace.o $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a | $$(@D)/
 	$(NFORT) $(NFORTFLAGS) -ftrace -cxxlib -fopenmp -o $@ $^ \
 		$(NLDFLAGS) $(BVELIB)/libaveoVE.a $(BVELIB)/liburpcVE.a \
 		-lveio -lpthread

--- a/test/Makefile
+++ b/test/Makefile
@@ -90,4 +90,4 @@ $(BB)/%.sh: %.sh | $$(@D)/
 	cp -p $< $@
 
 clean:
-	rm -f $(TESTS)
+	rm -f $(TESTS) $(TESTS) $(VELIBS) $(STATICS) $(SCRIPTS)


### PR DESCRIPTION
We fixed makefiles as follows:

Fixed Makefile to link liburpcVE_omp.a with aveorun and aveorun-ftrace to pin threads when VE_CORE_NUMBER is set
Updated Makefile to relink aveorun and aveorun-ftrace when archive files are updated
Updated Makefile to update spec files, a tarball, rpm files unconditionally
Updated Makefile to remove all files under build directory