### PR TITLE
Fixed the issue newpeer_handler() wait forever when VE_CORE_NUMBER is set

### DIFF
--- a/src/veo_urpc_ve.c
+++ b/src/veo_urpc_ve.c
@@ -69,7 +69,6 @@ static int newpeer_handler(urpc_peer_t *up, urpc_mb_t *m, int64_t req,
   pthread_attr_destroy(&_a);
 
   __num_ve_peers++;
-  while (new_up->core != core);
 
   ve_urpc_init_dma(up, up->core);
   


### PR DESCRIPTION
We removed unnecessary wait from newpeer_handler().
