### PR TITLE
New APIs to handle heterogeneous memory using a pointer

### DIFF
--- a/aveo.spec.in
+++ b/aveo.spec.in
@@ -59,4 +59,5 @@ make install-vh DEST=%{_prefix} VEDEST=%{_subprefix} PREF=%{buildroot}
 
 %files devel
 %{_includedir}/ve_offload.h
+%{_includedir}/veo_hmem.h
 %{_libdir}/libveo.so

--- a/aveorun.spec.in
+++ b/aveorun.spec.in
@@ -40,6 +40,7 @@ This package includes header files of VE offloading Framework
 %define _vebindir %{_subprefix}/bin
 %define _velibexecdir %{_subprefix}/libexec
 %define _velibdir %{_subprefix}/lib
+%define _veincludedir %{_subprefix}/include
 %define __strip /opt/nec/ve/bin/nstrip
 %define _unpackaged_files_terminate_build 0
 %if 0%{?rhel} == 8
@@ -65,14 +66,18 @@ make install-ve DEST=%{_prefix} VEDEST=%{_subprefix} PREF=%{buildroot}
 %{_libexecdir}/aveorun
 %{_velibdir}/libaveoVE.so.1
 %{_velibdir}/libaveoVE.so.1.0.0
+%{_velibdir}/libveohmem.so.1
+%{_velibdir}/libveohmem.so.1.0.0
 
 %files devel
 %{_velibdir}/libaveoVE.a
 %{_velibdir}/liburpcVE.a
 %{_velibdir}/liburpcVE_omp.a
 %{_velibdir}/libaveoVE.so
+%{_velibdir}/libveohmem.so
 %{_vebindir}/mk_veorun_static
 %{_vebindir}/relink_aveorun
 %{_libexecdir}/gen_veorun_static_symtable
 %{_libexecdir}/mk_veorun_static
 %{_libexecdir}/relink_aveorun
+%{_veincludedir}/veo_hmem.h

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -753,7 +753,7 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          = veo_api.cpp *.md
+FILE_PATTERNS          = veo_api.cpp veo_hmem.cpp *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/make_aveo.inc
+++ b/make_aveo.inc
@@ -38,6 +38,7 @@ BLIB    = $(BUILD)/lib64
 BVELIB	= $(BUILD)/lib
 BLIBEX  = $(BUILD)/libexec
 BINC    = $(BUILD)/include
+BVEINC    = $(BUILD)/include-ve
 
 # rule for creating directories
 %/:

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -55,7 +55,7 @@ int Context::close()
     int status;
     VEO_TRACE("entering waitpid(%d)", this->up->child_pid);
     waitpid(this->up->child_pid, &status, 0);
-    VEO_DEBUG("waitpid(%d) returned status=%d\n", this->up->child_pid, status);
+    VEO_DEBUG("waitpid(%d) returned status=%d", this->up->child_pid, status);
     this->up->child_pid = -1;
   }
   rc = vh_urpc_peer_destroy(this->up);

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,21 +17,24 @@ GPPFLAGS := $(GPPFLAGS) $(DEFINES)
 
 VHLIB_OBJS := $(addprefix $(BVH)/,\
  ProcHandle.o Context.o AsyncTransfer.o Command.o CallArgs.o veo_api.o \
- veo_urpc.o veo_urpc_vh.o log.o)
+ veo_urpc.o veo_urpc_vh.o log.o veo_hmem.o)
 
-VELIB_OBJS := $(addprefix $(BVE)/,veo_urpc.o veo_urpc_ve.o log.o)
+AVEORUN_OBJS := $(addprefix $(BVE)/,veo_urpc.o veo_urpc_ve.o log.o veo_hmem.o)
+HMEM_OBJS := $(addprefix $(BVE)/,veo_hmem.o)
+VELIB_OBJS := $(AVEORUN_OBJS) $(HMEM_OBJS)
 
 LIBS = $(addprefix $(BLIB)/,libveo.so libveo.a libveo.so.1 libveo.so.1.0.0)
 ARCS = $(addprefix $(BLIB)/,libveo.a)
-VELIBS = $(addprefix $(BVELIB)/,libaveoVE.so.1.0.0 libaveoVE.so libaveoVE.so.1)
+VELIBS = $(addprefix $(BVELIB)/,libaveoVE.so.1.0.0 libaveoVE.so libaveoVE.so.1 \
+	libveohmem.so.1.0.0 libveohmem.so libveohmem.so.1)
 VEARCS = $(addprefix $(BVELIB)/,libaveoVE.a)
 PROGS = $(addprefix $(BLIBEX)/,aveorun aveorun-ftrace relink_aveorun mk_veorun_static gen_veorun_static_symtable)
-INCLUDES := $(addprefix $(BINC)/,ve_offload.h veo_time.h)
-
+INCLUDES := $(addprefix $(BINC)/,ve_offload.h veo_time.h veo_hmem.h)
+VEINCLUDES := $(addprefix $(BVEINC)/,veo_hmem.h)
 
 ALL: all-ve all-vh
 
-all-ve: $(VELIBS) $(VEARCS) $(PROGS)
+all-ve: $(VEINCLUDES) $(VELIBS) $(VEARCS) $(PROGS)
 all-vh: $(INCLUDES) $(LIBS) $(ARCS)
 
 .PRECIOUS: $(DEST)/ $(DEST)%/
@@ -42,13 +45,14 @@ all-vh: $(INCLUDES) $(LIBS) $(ARCS)
 install: install-ve install-vh
 
 install-ve: all-ve
-	mkdir -p $(PREF)$(VEDEST)/lib/ $(PREF)$(dir $(VEORUN_BIN))/ $(PREF)$(DEST)/libexec/ $(PREF)$(VEDEST)/bin/
+	mkdir -p $(PREF)$(VEDEST)/lib/ $(PREF)$(dir $(VEORUN_BIN))/ $(PREF)$(DEST)/libexec/ $(PREF)$(VEDEST)/bin/ $(PREF)$(VEDEST)/include
 	/usr/bin/install -t $(PREF)$(VEDEST)/lib $(VELIBS)
 	( cd $(PREF)$(VEDEST)/lib; ln -sf libaveoVE.so.1.0.0 libaveoVE.so; ln -sf libaveoVE.so.1.0.0 libaveoVE.so.1)
 	/usr/bin/install -t $(PREF)$(VEDEST)/lib -m 0644 $(VEARCS)
 	/usr/bin/cp -P $(BLIBEX)/* $(PREF)$(dir $(VEORUN_BIN))
 	ln -sf $(DEST)/libexec/mk_veorun_static $(PREF)$(VEDEST)/bin/mk_veorun_static
 	ln -sf $(DEST)/libexec/relink_aveorun $(PREF)$(VEDEST)/bin/relink_aveorun
+	/usr/bin/install -t $(PREF)$(VEDEST)/include -m 0644 $(VEINCLUDES)
 
 install-vh: all-vh
 	mkdir -p $(PREF)$(DEST)/lib64/ $(PREF)$(DEST)/include/
@@ -67,7 +71,7 @@ install-vh: all-vh
 %/log.o: log.cpp log.h
 %/aveorun.o: aveorun.c veo_urpc.h
 %/aveorun-ftrace.o: aveorun.c veo_urpc.h
-
+%/veo_hmem.o: veo_hmem.cpp veo_hmem.h veo_hmem_macros.h
 
 .SECONDEXPANSION:
 
@@ -75,7 +79,10 @@ install-vh: all-vh
 $(BINC)/%.h: %.h | $$(@D)/
 	/usr/bin/install -t $(BINC) $<
 
-$(BVELIB)/libaveoVE.so.1.0.0: $(VELIB_OBJS) | $$(@D)/
+$(BVEINC)/%.h: %.h | $$(@D)/
+	/usr/bin/install -t $(BVEINC) $<
+
+$(BVELIB)/libaveoVE.so.1.0.0: $(AVEORUN_OBJS) | $$(@D)/
 	$(NCPP) -Wl,-zdefs $(NCPPFLAGS) -fopenmp -fpic -shared \
 	-Wl,-soname=libaveoVE.so.1 -o $@ $^ $(BVELIB)/liburpcVE_omp.a \
 	$(NLDFLAGS) -lveio -lveftrace -ldl
@@ -84,6 +91,17 @@ $(BVELIB)/libaveoVE.so.1: $(BVELIB)/libaveoVE.so.1.0.0
 	ln -sf $< $@
 
 $(BVELIB)/libaveoVE.so: $(BVELIB)/libaveoVE.so.1
+	ln -sf $< $@
+
+$(BVELIB)/libveohmem.so.1.0.0: $(HMEM_OBJS) | $$(@D)/
+	$(NCPP) -Wl,-zdefs $(NCPPFLAGS) -fpic -shared \
+	-Wl,-soname=libveohmem.so.1 -o $@ $^ \
+	$(NLDFLAGS) -Wl,-z,max-page-size=0x200000
+
+$(BVELIB)/libveohmem.so.1: $(BVELIB)/libveohmem.so.1.0.0
+	ln -sf $< $@
+
+$(BVELIB)/libveohmem.so: $(BVELIB)/libveohmem.so.1
 	ln -sf $< $@
 
 $(BLIB)/libveo.so.1.0.0: $(VHLIB_OBJS) | $$(@D)/
@@ -96,7 +114,7 @@ $(BLIB)/libveo.so.1: $(BLIB)/libveo.so.1.0.0
 $(BLIB)/libveo.so: $(BLIB)/libveo.so.1.0.0
 	ln -sf $< $@
 
-$(BVELIB)/libaveoVE.a: $(VELIB_OBJS) $(BVE)/aveorun.o | $$(@D)/
+$(BVELIB)/libaveoVE.a: $(AVEORUN_OBJS) $(BVE)/aveorun.o | $$(@D)/
 	$(NAR) rv $@ $^
 
 $(BLIB)/libveo.a: $(VHLIB_OBJS) | $$(@D)/
@@ -151,5 +169,5 @@ $(BVE)/aveorun-ftrace.o: aveorun.c | $$(@D)/
 
 clean:
 	rm -f $(VHLIB_OBJS) $(VELIB_OBJS) $(VELIB_OBJS_OMP) $(LIBS) $(LIBS) \
-		$(VELIBS) $(VEARCS) $(PROGS) $(INCLUDES) \
+		$(VELIBS) $(VEARCS) $(PROGS) $(INCLUDES) $(VEINCLUDES) \
 		$(BVE)/aveorun.o $(BVE)/aveorun-ftrace.o 

--- a/src/ProcHandle.hpp
+++ b/src/ProcHandle.hpp
@@ -46,6 +46,7 @@ public:
   ProcHandle(int, char *);
   ~ProcHandle() { this->exitProc(); }
 
+  static ProcHandle *getProcHandle(int);
   uint64_t loadLibrary(const char *);
   int unloadLibrary(const uint64_t libhdl);
   uint64_t getSym(const uint64_t, const char *);
@@ -56,6 +57,8 @@ public:
   int readMem(void *, uint64_t, size_t);
   int writeMem(uint64_t, const void *, size_t);
   int exitProc(void);
+  int getProcIdentifier(void);
+  int numProcs(void);
 
   int numContexts(void);
   Context *getContext(int);

--- a/src/libaveoVH.map
+++ b/src/libaveoVH.map
@@ -33,8 +33,13 @@ VERSION_1 {
     veo_call_wait_result;
     veo_alloc_mem;
     veo_free_mem;
+    veo_alloc_hmem;
+    veo_free_hmem;
     veo_read_mem;
     veo_write_mem;
+    veo_hmemcpy;
+    veo_args_set_hmem;
+    veo_is_ve_addr;
     veo_async_read_mem;
     veo_async_write_mem;
     veo_context_open_with_attr;

--- a/src/libaveoVH.map
+++ b/src/libaveoVH.map
@@ -52,6 +52,9 @@ VERSION_1 {
     veo_num_contexts;
     veo_get_context;
     veo_context_sync;
+    veo_is_ve_addr;
+    veo_get_virt_addr_ve;
+    veo_get_virt_addr_vh;
   local:
     *;
 };

--- a/src/ve_offload.h
+++ b/src/ve_offload.h
@@ -31,22 +31,9 @@
 
 #define VEO_REQUEST_ID_INVALID (~0UL)
 
-#define VEO_MAX_MPI_PROCS 8
-#define IDENT_OFFSET_BITS 59 // bit 62:59 is used as VE process identifier.
-#define VEADDR_MBITS	0x8000000000000000 // bit 63 VE virtual adress mask bits
-#define PIDENT_MBITS	0x7800000000000000 // bit 62:59 VE process identifier mask bits
-#define VEIDENT_MBITS	(VEADDR_MBITS | PIDENT_MBITS)
-#define SET_VE_FLAG(addr)       (VEADDR_MBITS | (uint64_t)addr)
-#define IS_VE(addr)             (VEADDR_MBITS & (uint64_t)addr)
-#define VIRT_ADDR_VE(addr)      (~VEIDENT_MBITS & (uint64_t)addr)
-// this MACRO set addr to process identifier number.
-#define SET_PROC_FLAG(addr, proc_ident)	((uint64_t)addr | (uint64_t)proc_ident \
-					<<(int)IDENT_OFFSET_BITS)
-#define GET_PROC_IDENT(addr)	(((uint64_t)addr & PIDENT_MBITS) \
-				>>(int)IDENT_OFFSET_BITS)
-
 #include <stdint.h>
 #include <stddef.h>
+#include "veo_hmem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,13 +78,8 @@ int veo_unload_library(struct veo_proc_handle *, const uint64_t);
 uint64_t veo_get_sym(struct veo_proc_handle *, uint64_t, const char *);
 int veo_alloc_mem(struct veo_proc_handle *, uint64_t *, const size_t);
 int veo_free_mem(struct veo_proc_handle *, uint64_t);
-int veo_alloc_hmem(struct veo_proc_handle *, void **, const size_t);
-int veo_free_hmem(void *);
 int veo_read_mem(struct veo_proc_handle *, void *, uint64_t, size_t);
 int veo_write_mem(struct veo_proc_handle *, uint64_t, const void *, size_t);
-int veo_hmemcpy(void *, const void *, size_t);
-int veo_is_ve_addr(void *);
-int veo_args_set_hmem(struct veo_args *, int, void *);
 int veo_num_contexts(struct veo_proc_handle *);
 struct veo_thr_ctxt *veo_get_context(struct veo_proc_handle *, int);
 
@@ -142,10 +124,14 @@ struct veo_thr_ctxt_attr *veo_alloc_thr_ctxt_attr(void);
 int veo_free_thr_ctxt_attr(struct veo_thr_ctxt_attr *);
 int veo_set_thr_ctxt_stacksize(struct veo_thr_ctxt_attr *, size_t);
 int veo_get_thr_ctxt_stacksize(struct veo_thr_ctxt_attr *, size_t *);
-//int veo_get_proc_identifier(struct veo_proc_handle *);
 
 const char *veo_version_string(void);
 int veo_api_version(void);
+
+int veo_alloc_hmem(struct veo_proc_handle *, void **, const size_t);
+int veo_free_hmem(void *);
+int veo_hmemcpy(void *, void *, size_t);
+int veo_args_set_hmem(struct veo_args *, int, void *);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/ve_offload.h
+++ b/src/ve_offload.h
@@ -24,12 +24,26 @@
 #ifndef _VE_OFFLOAD_H_
 #define _VE_OFFLOAD_H_
 
-#define VEO_API_VERSION 9
+#define VEO_API_VERSION 10
 #define VEO_SYMNAME_LEN_MAX (255)
 #define VEO_LOG_CATEGORY "veos.veo.veo"
 #define VEO_MAX_NUM_ARGS (256)
 
 #define VEO_REQUEST_ID_INVALID (~0UL)
+
+#define VEO_MAX_MPI_PROCS 8
+#define IDENT_OFFSET_BITS 59 // bit 62:59 is used as VE process identifier.
+#define VEADDR_MBITS	0x8000000000000000 // bit 63 VE virtual adress mask bits
+#define PIDENT_MBITS	0x7800000000000000 // bit 62:59 VE process identifier mask bits
+#define VEIDENT_MBITS	(VEADDR_MBITS | PIDENT_MBITS)
+#define SET_VE_FLAG(addr)       (VEADDR_MBITS | (uint64_t)addr)
+#define IS_VE(addr)             (VEADDR_MBITS & (uint64_t)addr)
+#define VIRT_ADDR_VE(addr)      (~VEIDENT_MBITS & (uint64_t)addr)
+// this MACRO set addr to process identifier number.
+#define SET_PROC_FLAG(addr, proc_ident)	((uint64_t)addr | (uint64_t)proc_ident \
+					<<(int)IDENT_OFFSET_BITS)
+#define GET_PROC_IDENT(addr)	(((uint64_t)addr & PIDENT_MBITS) \
+				>>(int)IDENT_OFFSET_BITS)
 
 #include <stdint.h>
 #include <stddef.h>
@@ -77,8 +91,13 @@ int veo_unload_library(struct veo_proc_handle *, const uint64_t);
 uint64_t veo_get_sym(struct veo_proc_handle *, uint64_t, const char *);
 int veo_alloc_mem(struct veo_proc_handle *, uint64_t *, const size_t);
 int veo_free_mem(struct veo_proc_handle *, uint64_t);
+int veo_alloc_hmem(struct veo_proc_handle *, void **, const size_t);
+int veo_free_hmem(void *);
 int veo_read_mem(struct veo_proc_handle *, void *, uint64_t, size_t);
 int veo_write_mem(struct veo_proc_handle *, uint64_t, const void *, size_t);
+int veo_hmemcpy(void *, const void *, size_t);
+int veo_is_ve_addr(void *);
+int veo_args_set_hmem(struct veo_args *, int, void *);
 int veo_num_contexts(struct veo_proc_handle *);
 struct veo_thr_ctxt *veo_get_context(struct veo_proc_handle *, int);
 
@@ -123,6 +142,7 @@ struct veo_thr_ctxt_attr *veo_alloc_thr_ctxt_attr(void);
 int veo_free_thr_ctxt_attr(struct veo_thr_ctxt_attr *);
 int veo_set_thr_ctxt_stacksize(struct veo_thr_ctxt_attr *, size_t);
 int veo_get_thr_ctxt_stacksize(struct veo_thr_ctxt_attr *, size_t *);
+//int veo_get_proc_identifier(struct veo_proc_handle *);
 
 const char *veo_version_string(void);
 int veo_api_version(void);

--- a/src/veo_api.cpp
+++ b/src/veo_api.cpp
@@ -316,6 +316,64 @@ int veo_alloc_mem(veo_proc_handle *h, uint64_t *addr, const size_t size)
   return 0;
 }
 
+/*
+int veo_get_proc_identifier(veo_proc_handle *h)
+{
+  return ProcHandleFromC(h)->getProcIdentifier();
+}
+*/
+
+/**
+ * @brief Allocate a VE memory buffer
+ *
+ * This function returns the address with the process identifier. 
+ * Since the number of processes that can be identified by the process 
+ * identifier is 8, this function will fail if the user attempts to 
+ * identify more than 8 processes. The memory allocated using this 
+ * function must be transferred to the VE side with veo_args_set_hmem() 
+ * and freed with veo_free_hmem(). And the data transfer of this 
+ * memory between VH and VE must be done by veo_hmemcpy(). veo_hmemcpy() 
+ * allows user to transfer data from VH to VE, from VE to VH, or from 
+ * VH to VH. The transfer direction is determined from the identifier 
+ * of the virtual address of the argument passed to veo_hmemcpy(). 
+ * User can check with veo_is_ve_addr() that the target address is 
+ * flagged with the VE process identifier. So, if user pass this 
+ * memory to veo_is_ve_addr(), it will return 1.
+ *
+ * @param h VEO process handle
+ * @param addr [out] a pointer to VEMVA address with the identifier
+ * @param size [in] size in bytes
+ * @retval 0 memory allocation succeeded.
+ * @retval -1 memory allocation or proc identifier acquisition failed.
+ * @retval -2 internal error.
+ */
+int veo_alloc_hmem(veo_proc_handle *h, void **addr, const size_t size)
+{
+  uint64_t veaddr = 0UL;
+  int ret = -1;
+  try {
+    int nprocs = ProcHandleFromC(h)->numProcs();
+    VEO_DEBUG("nprocs = %d", nprocs);
+    if (nprocs > VEO_MAX_MPI_PROCS) {
+      VEO_ERROR("VEO procs exceeded VEO_MAX_MPI_PROCS.");
+      return -1;
+    }
+    ret = veo_alloc_mem(h, &veaddr, size);
+    if (ret != 0)
+      return ret;
+    //std::lock_guard<std::mutex> lock(ProcHandle::__procs_mtx);
+    int proc_ident = ProcHandleFromC(h)->getProcIdentifier();
+    if (proc_ident < 0)
+      return proc_ident;
+    *addr = (void *)SET_VE_FLAG(veaddr);
+    *addr = (void *)SET_PROC_FLAG(*addr, proc_ident);
+  } catch (VEOException &e) {
+    VEO_ERROR("failed to allocate memory : %s", e.what());
+    return -1;
+  }
+  return ret;
+}
+
 /**
  * @brief Free a VE memory buffer
  *
@@ -332,6 +390,34 @@ int veo_free_mem(veo_proc_handle *h, uint64_t addr)
     return -1;
   }
   return 0;
+}
+
+/**
+ * @brief Free a VE memory buffer
+ *
+ * This function free the memory allocated by veo_alloc_hmem().
+ *
+ * @param h VEO process handle
+ * @param addr [in] a pointer to VEMVA address
+ * @retval 0 memory is successfully freed.
+ * @retval -1 internal error.
+ */
+int veo_free_hmem(void *addr)
+{
+  int ret = -1;
+  try {
+    //std::lock_guard<std::mutex> lock(ProcHandle::__procs_mtx);
+    if (!veo_is_ve_addr(addr))
+      return -1;
+    int proc_ident = GET_PROC_IDENT(addr);
+    veo::ProcHandle *p = veo::ProcHandle::getProcHandle(proc_ident);
+    veo_proc_handle *h = p->toCHandle();
+    ret = veo_free_mem(h, VIRT_ADDR_VE(addr));
+  } catch (VEOException &e) {
+    VEO_ERROR("failed to free memory : %s", e.what());
+    return -1;
+  }
+  return ret;
 }
 
 /**
@@ -369,6 +455,89 @@ int veo_write_mem(veo_proc_handle *h, uint64_t dst, const void *src,
   } catch (VEOException &e) {
     return -1;
   }
+}
+
+/**
+ * @brief Copy VE/VH memory
+ *
+ * This function copies memory. When only the destination is the VE
+ * memory allocated by veo_alloc_hmem(), the data is transferred 
+ * from VH to VE. When only the source is the VE memory allocated by
+ * veo_alloc_hmem(), the data is transferred from VE to VH. When 
+ * both the source and the destination are VH memory, they are 
+ * copied on VH. When both the source and the destination are VE 
+ * memory allocated by veo_alloc_hmem(), veo_hmemcpy() returns a 
+ * failure.
+ *
+ * @param dst a pointer to destination
+ * @param src a pointer to source
+ * @param size size in byte
+ * @return zero upon success; negative upon failure.
+ */
+int veo_hmemcpy(void *dest, const void *src, size_t size)
+{
+  try
+  {
+    //std::lock_guard<std::mutex> lock(ProcHandle::__procs_mtx);
+    veo_proc_handle *h;
+    veo::ProcHandle *p;
+    int proc_ident = -1;
+    if (IS_VE(dest) && !IS_VE(src)) {
+      proc_ident = GET_PROC_IDENT(dest);
+      p = veo::ProcHandle::getProcHandle(proc_ident);
+      h = p->toCHandle();
+      return veo_write_mem(h, VIRT_ADDR_VE(dest), src, size);
+    } else if (!IS_VE(dest) && IS_VE(src)) {
+      proc_ident = GET_PROC_IDENT(src);
+      p = veo::ProcHandle::getProcHandle(proc_ident);
+      h = p->toCHandle();
+      return veo_read_mem(h, dest, VIRT_ADDR_VE(src), size);
+    } else if (!IS_VE(dest) && !IS_VE(src)) {
+      memcpy(dest, src, size);
+      return 0;
+    }
+    return -1;
+  } catch (std::out_of_range &e) {
+    VEO_ERROR("failed to get process handler: %s", e.what());
+    return -1;
+  } catch (VEOException &e) 
+  {
+    return -1;
+  }
+}
+
+/**
+ * @brief set a pointer argument
+ *
+ * This function removes the identifier from the address allocated 
+ * by veo_alloc_hmem() and passes the valid pointer to VE.
+ *
+ * @param ca veo_args
+ * @param argnum the argnum-th argument
+ * @param val a pointer to value to be set
+ * @return zero upon success; negative upon failure.
+ */
+int veo_args_set_hmem(struct veo_args *ca, int argnum, void *val)
+{
+  //std::lock_guard<std::mutex> lock(ProcHandle::__procs_mtx);
+  if (!veo_is_ve_addr(val))
+    return -1;
+  return veo_args_set_u64(ca, argnum, VIRT_ADDR_VE(val));
+}
+
+/**
+ * @brief check the address
+ *
+ * This function determines if the address is allocated by 
+ * veo_alloc_hmem(). 
+ *
+ * @param addr a pointer to virtual address
+ * @return one when addr was allocated by veo_alloc_hmem();
+ *         zero when addr was not allocated by veo_alloc_hmem().
+ */
+int veo_is_ve_addr(void *addr)
+{
+  return IS_VE(addr) ? 1 : 0;
 }
 
 /**

--- a/src/veo_hmem.cpp
+++ b/src/veo_hmem.cpp
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "veo_hmem.h"
+#include "veo_hmem_macros.h"
+
+/**
+ * \defgroup veohmemapi VEO HMEM API
+ *
+ * VE heterogeneous memory API functions.
+ * Include "ve_offload.h" header from VH program. Specify -lveo when you link VH program.
+ * Include "veo_hmem.h" header from VH program. Specify -lveohmem when you link VE program.
+ */
+//@{
+
+/**
+ * @brief check the address
+ *
+ * This function determines if the address is allocated by
+ * veo_alloc_hmem().
+ *
+ * @param addr a pointer to virtual address
+ * @return one when addr was allocated by veo_alloc_hmem();
+ *         zero when addr was not allocated by veo_alloc_hmem().
+ */
+int veo_is_ve_addr(void *addr)
+{
+  return IS_VE(addr) ? 1 : 0;
+}
+
+/**
+ * @brief get a virtual address of VE memory without identifier
+ * allocated by veo_alloc_hmem().
+ * @param addr a pointer to heterogeneous memory
+ * @return a virtual address without identifier;
+ *         NULL if the specified memory is not VE memory
+ */
+void* veo_get_virt_addr_ve(void *addr)
+{
+  if (veo_is_ve_addr(addr))
+    return (void *)(~VEIDENT_MBITS & (uint64_t)addr);
+  return NULL;
+}
+
+/**
+ * @brief get a virtual address of VH memory without identifier
+ * allocated by veo_alloc_hmem().
+ * @param addr a pointer to heterogeneous memory
+ * @return a virtual address without identifier;
+ *         NULL if the specified memory is not VH memory
+ */
+void* veo_get_virt_addr_vh(void *addr)
+{
+  if (!veo_is_ve_addr(addr))
+    return addr;
+  return NULL;
+}
+
+//@}

--- a/src/veo_hmem.h
+++ b/src/veo_hmem.h
@@ -1,0 +1,16 @@
+/**
+ * @file veo_hmem.h
+ */
+#ifndef _VEO_HMEM_H_
+#define _VEO_HMEM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+int veo_is_ve_addr(void *);
+void *veo_get_virt_addr_ve(void *);
+void *veo_get_virt_addr_vh(void *);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+#endif

--- a/src/veo_hmem_macros.h
+++ b/src/veo_hmem_macros.h
@@ -1,0 +1,21 @@
+/**
+ * @file veo_hmem_macros.h
+ */
+#ifndef _HMEM_MACROS_H_
+#define _HMEM_MACROS_H_
+
+
+#define VEO_MAX_HMEM_PROCS 16
+#define IDENT_OFFSET_BITS 59 // bit 62:59 is used as VE process identifier.
+#define VEADDR_MBITS    0x8000000000000000 // bit 63 VE virtual adress mask bits
+#define PIDENT_MBITS    0x7800000000000000 // bit 62:59 VE process identifier mask bits
+#define VEIDENT_MBITS   (VEADDR_MBITS | PIDENT_MBITS)
+#define SET_VE_FLAG(addr)       (VEADDR_MBITS | (uint64_t)addr)
+#define IS_VE(addr)             (VEADDR_MBITS & (uint64_t)addr)
+#define VIRT_ADDR_VE(addr)      (~VEIDENT_MBITS & (uint64_t)addr)
+#define SET_PROC_IDENT(addr, proc_ident) ((uint64_t)addr | (uint64_t)proc_ident \
+                                        <<(int)IDENT_OFFSET_BITS)
+#define GET_PROC_IDENT(addr)    (((uint64_t)addr & PIDENT_MBITS) \
+                                >>(int)IDENT_OFFSET_BITS)
+
+#endif

--- a/src/veo_urpc.c
+++ b/src/veo_urpc.c
@@ -23,7 +23,6 @@ static int gettid(void)
   return syscall(SYS_gettid);
 }
 
-
 //
 // Handlers
 //
@@ -188,7 +187,6 @@ static int recvbuff_handler(urpc_peer_t *up, urpc_mb_t *m, int64_t req,
 
   urpc_unpack_payload(payload, plen, (char *)"LLL", &src, &dst, &size);
   VEO_DEBUG("src=%p dst=%p size=%lu", (void *)src, (void *)dst, size);
-
   int64_t new_req = urpc_generic_send(up, URPC_CMD_SENDBUFF, (char *)"LP",
                                       dst, (void *)src, size);
   CHECK_REQ(new_req, req);

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,8 @@ TESTS = $(addprefix $(BB)/,test_callsync test_callasync test_stackargs \
  test_child1 test_child2 test_async_mem test_thread_main_call_race \
  test_2ctx_callasync test_omp test_omp_static test_arith_ftrace \
  test_stackout test_unloadlib test_noproc test_memtransfers test_multithread_alloc_write_read_free \
- test_veexcept_async bandwidth_stackargs bandwidth_async test_omp_2ctx)
+ test_veexcept_async bandwidth_stackargs bandwidth_async test_omp_2ctx \
+ test_hmem)
 
 VELIBS = $(addprefix $(BB)/,libvehello.so libvehello2.so \
  libvestackargs.so libveexcept.so libveasyncmem.so libvetestomp.so \

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,7 @@ TESTS = $(addprefix $(BB)/,test_callsync test_callasync test_stackargs \
 
 VELIBS = $(addprefix $(BB)/,libvehello.so libvehello2.so \
  libvestackargs.so libveexcept.so libveasyncmem.so libvetestomp.so \
- libvestackout.so libvearith_ftrace.so)
+ libvestackout.so libvearith_ftrace.so libvehmem.so)
 
 STATICS = $(addprefix $(BB)/, veorun_testomp)
 
@@ -66,10 +66,10 @@ $(BB)/%: %.cpp  | $$(@D)/
 	$(GPP) $(GPPFLAGS) -fpic $(LDFLAGS) -o $@ $< -lveo
 
 $(BB)/%.so: $(BVE)/%.o  | $$(@D)/
-	$(NCC) $(NCCFLAGS) -shared -fpic $(LDFLAGS) -o $@ $< -lveftrace
+	$(NCC) $(NCCFLAGS) -shared -fpic $(NLDFLAGS) -o $@ $< -lveftrace -lveohmem
 
 $(BB)/%_ftrace.so: $(BVE)/%_ftrace.o  | $$(@D)/
-	$(NCC) $(NCCFLAGS) -ftrace -shared -fpic $(LDFLAGS) -o $@ $< -lveftrace
+	$(NCC) $(NCCFLAGS) -ftrace -shared -fpic $(NLDFLAGS) -o $@ $< -lveftrace
 
 $(BB)/veorun_%: $(BVE)/libve%.o | $$(@D)/
 	if [ -x $(BLIBEX)/relink_aveorun ]; then \

--- a/test/libvehello.c
+++ b/test/libvehello.c
@@ -30,3 +30,32 @@ uint64_t empty2(void)
   empty_cnt2++;
   return empty_cnt2;
 }
+
+uint64_t
+init( int *p, int v, int n )
+{
+    printf( "VE init %d %d\n", v, n );
+    fflush( stdout );
+
+    int i;
+    for ( i = 0; i < n; i++ ) p[i] = v + 1;
+
+    return (uint64_t)p;
+}
+
+uint64_t
+check( int *p, int v, int n )
+{
+    printf( "VE check %d %d\n", v, n );
+    fflush( stdout );
+
+    int i;
+    for ( i = 0; i < n; i++ ) {
+        if ( p[i] != v ) {
+            printf("p[%d] = %d\n", i, p[i]);
+            break;
+        }
+    }
+
+    return i < n ? ~0 : 0;
+}

--- a/test/libvehmem.c
+++ b/test/libvehmem.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdint.h>
+
+int64_t buffer = 0xdeadbeefdeadbeef;
+
+uint64_t print_buffer()
+{
+  printf("0x%016lx\n", buffer);
+  fflush(stdout);
+  return 1;
+}
+
+uint64_t hello(int i)
+{
+  printf("Hello, %d\n", i);
+  fflush(stdout);
+  return i + 1;
+}
+
+uint64_t empty_cnt = 0;
+uint64_t empty(void)
+{
+  empty_cnt++;
+  return empty_cnt;
+}
+
+uint64_t empty_cnt2 = 0;
+uint64_t empty2(void)
+{
+  empty_cnt2++;
+  return empty_cnt2;
+}
+
+uint64_t
+init( int *p, int v, int n )
+{
+    if (!veo_is_ve_addr(p))
+        return 0;
+    printf("p = %p\n", (void *)p);
+    p = (int *)veo_get_virt_addr_ve(p);
+    printf("p = %p\n", (void *)p);
+    printf( "VE init %d %d\n", v, n );
+    fflush( stdout );
+
+    int i;
+    for ( i = 0; i < n; i++ ) p[i] = v + 1;
+
+    return (uint64_t)p;
+}
+
+uint64_t
+check( int *p, int v, int n )
+{
+    printf("p = %p\n", (void *)p);
+    p = (int *)veo_get_virt_addr_ve(p);
+    printf("p = %p\n", (void *)p);
+    printf( "VE check %d %d\n", v, n );
+    fflush( stdout );
+
+    int i;
+    for ( i = 0; i < n; i++ ) {
+        if ( p[i] != v ) {
+            printf("p[%d] = %d\n", i, p[i]);
+            break;
+        }
+    }
+
+    return i < n ? ~0 : 0;
+}
+
+uint64_t
+test_addr(int *p)
+{
+    return veo_is_ve_addr(p);
+}

--- a/test/test_hmem.c
+++ b/test/test_hmem.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <ve_offload.h>
+#include <stdlib.h>
+
+int
+main()
+{
+	struct veo_proc_handle *proc = veo_proc_create(-1);
+	printf("proc = %p\n", proc);
+	struct veo_thr_ctxt    *ctx  = veo_context_open( proc );
+	struct veo_args        *argp = veo_args_alloc();
+	uint64_t handle = veo_load_library( proc, "./libvehello.so" );
+	void *vebuf;
+	int nelems = 1000;
+	int ret = veo_alloc_hmem( proc, &vebuf, sizeof(int) * nelems );
+	if (ret != 0) {
+		fprintf(stderr, "veo_alloc_mem failed: %d", ret);
+		exit(1);
+	}
+
+	ret = veo_args_set_hmem( argp, 0, vebuf );
+	if (ret != 0) {
+		fprintf(stderr, "veo_args_set_hmem failed: %d", ret);
+		exit(1);
+	}
+	veo_args_set_i32( argp, 1, 1 );
+	veo_args_set_i32( argp, 2, nelems );
+	uint64_t id     = veo_call_async_by_name( ctx, handle, "init", argp );
+	uint64_t rc;
+	if (veo_call_wait_result( ctx, id, &rc ) != 0)
+		exit(1);
+
+	void *q = vebuf;
+	if (veo_is_ve_addr(vebuf)) {
+		q = malloc( sizeof(int)*nelems );
+		// transfer data VE to VH
+		if (veo_hmemcpy(q, vebuf, sizeof(int)*nelems)) {
+			fprintf(stderr, "veo_hmemcpy failed: %d", ret);
+			exit(1);
+		}
+	}
+	// cast
+	int *a = (int *)q;
+	// check the transfered data.
+	for (int i = 0; i < nelems; i++) {
+		if (a[i] != 2) {
+			printf("veo_hmemcpy() failed a[%d] = %d\n", i, a[i]);
+			exit(1);
+		}
+	}
+
+	// restore 
+	for (int i = 0; i < nelems; i++)
+		a[i] = 1;
+	q = (void *)a;
+
+	// transfer data VH to VE
+	if (veo_is_ve_addr(vebuf)) {
+		if (veo_hmemcpy(vebuf, q, sizeof(int)*nelems)) {
+			fprintf(stderr, "veo_hmemcpy failed: %d", ret);
+			exit(1);
+		}
+	}
+	veo_args_clear( argp );
+
+	ret = veo_args_set_hmem(argp, 0, vebuf );
+	if (ret != 0) {
+		fprintf(stderr, "veo_args_set_hmem failed: %d", ret);
+		exit(1);
+	}
+	veo_args_set_i32( argp, 1, 1 );
+	veo_args_set_i32( argp, 2, nelems );
+
+	// check transferd data in check()
+	id = veo_call_async_by_name( ctx, handle, "check", argp );
+	if (veo_call_wait_result( ctx, id, &rc ) != 0)
+		exit(1);
+
+	printf( "rc:%lx (%s)\n", rc, rc ? "fail" : "success" );
+	if (rc)
+		exit(1);
+	if (veo_free_hmem( vebuf ) != 0)
+		exit(1);
+	veo_context_close( ctx );
+	veo_proc_destroy( proc );
+
+	return 0;
+}


### PR DESCRIPTION
New APIs to handle heterogeneous memory using a pointer.

   + veo_alloc_hmem()
   + veo_free_hmem()
   + veo_args_set_hmem()
   + veo_hmemcpy()
   + veo_is_ve_addr()

User programs can use a pointer variable to specify the location of VE memory